### PR TITLE
Resolved EPERM exception on Windows by using adm-zip package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "url": "git+ssh://git@github.com/gdotdesign/elm-github-install.git"
   },
   "dependencies": {
-    "semver-resolver": "0.4.0",
-    "extract-zip": "1.5.0",
-    "request": "2.74.0",
-    "colors": "1.1.2",
-    "semver": "5.3.0",
+    "adm-zip": "^0.4.7",
     "async": "1.5.2",
+    "colors": "1.1.2",
+    "request": "2.74.0",
+    "semver": "5.3.0",
+    "semver-resolver": "0.4.0",
     "tmp": "0.0.28"
   },
   "author": "Gusztáv Szikszai",


### PR DESCRIPTION
Resolves an "EPERM: operation not permitted, rename ..." exception thrown during the renaming of extracted packages. This error occurs on windows machines and is related to a [bug](https://github.com/maxogden/extract-zip/issues/7) in extract-zip where the callback is executed before the files can be renamed. Updating to use [adm-zip](https://www.npmjs.com/package/adm-zip) resolves the issue. [More info](https://github.com/Medium/phantomjs/issues/19).