### PR TITLE
resolve/download packages from arbitrary remotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
+*.iml
 node_modules

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/elm-github-install.svg)](https://badge.fury.io/js/elm-github-install)
 
 This node script and package that allows you to install Elm packages **directly
-from Github**, bypassing the package repository (package.elm-lang.org) while also
+from Github** (via https), or from **arbitrary git remotes** (ssh), bypassing the package repository (package.elm-lang.org) while also
 enabling restricted (effect manager and native) packages to be installed.
 
 ## Description
@@ -18,7 +18,7 @@ These are the steps the installer takes:
 * Reads the dependencies from `elm-package.json`
 * Transforms them to semver dependencies - **4.0.4 <= v < 5.0.0** becomes
 	**>= 4.0.4 < 5.0.0**
-* Loads the dependencies of the packages form Github and transforms them also
+* Loads the dependencies of the packages form Github (or remote), and transforms them also
 * Resolve the dependencies
 * Install resolved dependencies into `elm-stuff/packages`
 * Writes `elm-stuff/exact-dependencies.json` with the resolved dependencies
@@ -57,6 +57,17 @@ at version 1.3.0, you would do the following:
   ...
 }
 ```
+
+### Remote git repos
+
+Elm packages can also be hosted on arbitrary git remote repos. In order to use them, 
+you need to use a specific syntax in your package name :
+   
+    repoHostName:githubUser/repoName": "desiredVersion <= v < someLargerNumber"    
+
+When you put the host name before the semicolon, then `elm-github-install` will
+use git+ssh in order to fetch the package. It can take a bit longer, but allows to 
+use arbitrary remotes. 
 
 You can find the current version of the package in the repository's `elm-package.json`.
 

--- a/Readme.md
+++ b/Readme.md
@@ -61,13 +61,39 @@ at version 1.3.0, you would do the following:
 ### Remote git repos
 
 Elm packages can also be hosted on arbitrary git remote repos. In order to use them, 
-you need to use a specific syntax in your package name :
-   
-    repoHostName:githubUser/repoName": "desiredVersion <= v < someLargerNumber"    
+you need to use a config file named `elm-github-package.json`, located in the root 
+project dir, aside `elm-package.json`. This file indicates the hosts associated to the 
+packages that are not in github.
 
-When you put the host name before the semicolon, then `elm-github-install` will
-use git+ssh in order to fetch the package. It can take a bit longer, but allows to 
-use arbitrary remotes. 
+Here's an example using a fictious `myuser/my-elm-lib` package, that exists on a 
+private git/ssh remote, cloneable at `git@mygit.myco.com:myuser/my-elm-lib.git`.
+
+The `elm-package.json` is the usual one :
+
+```
+{
+  ...
+  "dependencies": {
+    ...
+    "myuser/my-elm-lib": "1.0.0 <= v < 1.1.0",
+    ...
+  }
+  ...
+}
+```
+
+And the `elm-github-package.json` config file defines the host :
+
+
+```
+{
+    "myuser/my-elm-lib" : "mygit.mycompany.com"    
+}
+```
+   
+With that, `elm-github-package` will use ssh for and the provided host in order 
+to resolve and download the `myuser/my-elm-lib` package.
+
 
 You can find the current version of the package in the repository's `elm-package.json`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ var getVersions = function (packageName) {
 
         var cmd;
         if (isSsh(packageName)) {
-            cmd = 'git ls-remote git+ssh://' + repoHost(packageName) + '/' + packageName + ".git | awk -F/ '{ print $3 }'";
+            cmd = 'git ls-remote git://' + repoHost(packageName) + '/' + packageName + ".git | awk -F/ '{ print $3 }'";
         } else {
             cmd = 'git ls-remote git://github.com/' + packageName + ".git | awk -F/ '{ print $3 }'";
         }

--- a/src/index.js
+++ b/src/index.js
@@ -259,7 +259,13 @@ module.exports = function () {
                 console.log('\nSome packages failed to install!');
             } else {
                 // Write te exact-dependencies.json
-                var depsStr = JSON.stringify(deps, null, '  ');
+                var cleanDeps = {};
+                Object.keys(deps).forEach(function (key) {
+                    var opts = packageNameToOptions(key);
+                    cleanDeps[opts.package] = getSemerVersion(deps[key].replace(/\s/g, ''));
+                });
+
+                var depsStr = JSON.stringify(cleanDeps, null, '  ');
                 fs.writeFileSync(path.resolve('elm-stuff/exact-dependencies.json'), depsStr);
                 console.log('\nPackages configured successfully!');
             }

--- a/src/index.js
+++ b/src/index.js
@@ -1,143 +1,270 @@
-var SemverResolver = require('semver-resolver').SemverResolver
-var exec = require('child_process').exec
-var request = require('request')
-var semver = require('semver')
-var colors = require('colors')
-var async = require('async')
-var path = require('path')
-var tmp = require('tmp')
-var fs = require('fs')
+var SemverResolver = require('semver-resolver').SemverResolver;
+var exec = require('child_process').exec;
+var request = require('request');
+var semver = require('semver');
+var colors = require('colors');
+var async = require('async');
+var path = require('path');
+var tmp = require('tmp');
+var fs = require('fs');
 var AdmZip = require('adm-zip');
 
 // Returns a function that downloads the given github repository at the given
 // reference and extracts it to elm-stuff/packages/owner/repository/reference
-installExternalPackage = function(package, ref) {
-  return function(callback){
-    // Skip if it's already downloaded
-    if(fs.existsSync(path.resolve('elm-stuff/packages/' + package + '/' + ref))){
-      console.log(' ●'.green, package + ' - ' + ref);
-      return callback()
+var installExternalPackage = function (packageName, ref) {
+    return function (callback) {
+
+        var opts = packageNameToOptions(packageName);
+
+        // Skip if it's already downloaded
+        if (fs.existsSync(path.resolve('elm-stuff/packages/' + opts.package + '/' + ref))) {
+            console.log(' ●'.blue, opts.package + ' - ' + ref + ' (already present)');
+            return callback()
+        }
+
+        var packagePathStr = 'elm-stuff/packages/' + opts.package;
+
+        // console.log("installExternalPackage: packagePathStr=" + packagePathStr);
+
+        if (opts.ssh) {
+
+            var cmd = 'rm -rf ' + packagePathStr +
+                ' && git clone --depth 1 --branch ' +
+                ref + ' git@' + opts.gitHubUrl +
+                ':' + opts.package + '.git ' + packagePathStr + '/' + ref;
+
+            // var cmd2 = 'echo "fooo"';
+
+            // console.log("installExternalPackage: cmd=" + cmd);
+
+            exec(cmd, function(error, stdout, stderr){
+                if (error) {
+                    console.log(' ●'.red, opts.package + ' - ' + ref, error, stdout, stderr);
+                    callback(error);
+                } else {
+                    console.log(' ●'.green, opts.package + ' - ' + ref + " (ssh@"
+                        + opts.gitHubUrl
+                        + ")"
+                    );
+                    callback();
+                }
+            });
+
+
+        } else {
+
+            var packagePath = path.resolve(packagePathStr);
+            var archiveUrl = 'https://' + opts.gitHubUrl + '/' + opts.package + '/archive/' + ref + '.zip';
+
+            // Set up a temp file to store the archive in
+            var tmpFile = tmp.fileSync({});
+
+            // Get the archive into the temp file
+            request
+                .get(archiveUrl)
+                .pipe(fs.createWriteStream(tmpFile.name))
+                .on('error', function(err) {
+                    callback(err);
+                })
+                .on('finish', function () {
+                    // Extract the contents to the directory
+                    var zip = new AdmZip(tmpFile.name);
+                    var repo = packageName.split('/').pop();
+                    zip.extractAllTo(path.resolve(packagePath), true);
+                    fs.renameSync(path.resolve(packagePath, repo + '-' + ref), path.resolve(packagePath, ref));
+                    console.log(' ●'.green, opts.package + ' - ' + ref);
+                    callback();
+                })
+        }
     }
-
-    var archiveUrl = 'https://github.com/' + package + '/archive/' + ref + '.zip'
-    var packagePath = path.resolve('elm-stuff/packages/' + package)
-
-    // Set up a temp file to store the archive in
-    var tmpFile = tmp.fileSync()
-
-    // Get the archive into the temp file
-    request
-      .get(archiveUrl)
-      .pipe(fs.createWriteStream(tmpFile.name))
-      .on('finish', function(){
-        // Extract the contents to the directory
-        var zip = new AdmZip(tmpFile.name);
-        var repo = package.split('/').pop();
-        zip.extractAllTo(path.resolve(packagePath));
-        fs.renameSync(path.resolve(packagePath, repo + '-' + ref),
-                          path.resolve(packagePath, ref));
-        console.log(' ●'.green, package + ' - ' + ref);
-        callback();
-      })
-  }
-}
+};
 
 // Converts an Elm dependency version into a semver.
 // For exmaple: 4.0.4 <= v < 5.0.0  becomes >= 4.0.4 < 5.0.0
-var getSemerVersion = function(version) {
-  var match = version.match(/(\d+\.\d+\.\d+)<=v<(\d+\.\d+\.\d+)/)
-  if(match) { return '>=' + match[1] + ' <' + match[2] }
-  var match = version.match(/(\d+\.\d+\.\d+)<=v<=(\d+\.\d+\.\d+)/)
-  if(match) { return '>=' + match[1] + ' <=' + match[2] }
-  var match = version.match(/(\d+\.\d+\.\d+)<v<=(\d+\.\d+\.\d+)/)
-  if(match) { '>' + match[1] + ' <=' + match[2] }
-  var match = version.match(/(\d+\.\d+\.\d+)<v<(\d+\.\d+\.\d+)/)
-  if(match) { '>' + match[1] + ' <' + match[2] }
-  return version
-}
+var getSemerVersion = function (version) {
+    var match = version.match(/(\d+\.\d+\.\d+)<=v<(\d+\.\d+\.\d+)/);
+    if (match) {
+        return '>=' + match[1] + ' <' + match[2];
+    }
+    match = version.match(/(\d+\.\d+\.\d+)<=v<=(\d+\.\d+\.\d+)/);
+    if (match) {
+        return '>=' + match[1] + ' <=' + match[2];
+    }
+    match = version.match(/(\d+\.\d+\.\d+)<v<=(\d+\.\d+\.\d+)/);
+    if (match) {
+        return '>' + match[1] + ' <=' + match[2];
+    }
+    match = version.match(/(\d+\.\d+\.\d+)<v<(\d+\.\d+\.\d+)/);
+    if (match) {
+        return '>' + match[1] + ' <' + match[2];
+    }
+    return version;
+};
 
 // Transform all Elm dependencies into the semver versions.
-var transformDependencies = function(deps){
-  var result = {}
-  Object.keys(deps).forEach(function(key) {
-    result[key] = getSemerVersion(deps[key].replace(/\s/g, ''))
-  })
-  return result
-}
+var transformDependencies = function (deps) {
+    var result = {};
+    Object.keys(deps).forEach(function (key) {
+        result[key] = getSemerVersion(deps[key].replace(/\s/g, ''));
+    });
+    return result;
+};
 
 // Get the dependencies for a given package and reference.
-var getDependencies = function(package, ref) {
-  return new Promise(function (fulfill, reject){
-    getPackageJson(package, ref)
-      .then(function(json){
-        fulfill(transformDependencies(json.dependencies))
-      })
-  })
-}
+var getDependencies = function (packageName, ref) {
+    return new Promise(function (fulfill, reject) {
+        getPackageJson(packageName, ref)
+            .then(function (json) {
+                fulfill(transformDependencies(json.dependencies));
+            })
+            .catch(function(err) {
+                reject(err);
+            });
+    });
+};
 
 
 // Get the contents of the elm-package.json of the given package and reference
-var getPackageJson = function(package, ref){
-  var packageUrl = 'https://github.com/' + package + '/raw/' + ref + '/elm-package.json'
+var getPackageJson = function (packageName, ref) {
 
-  return new Promise(function (fulfill, reject){
-    request.get(packageUrl, function(error, response, body){
-      fulfill(JSON.parse(body))
-    })
-  })
-}
+    // console.log("getPackageJson: package=" + package + ", ref=" + ref);
+    var opts = packageNameToOptions(packageName);
+
+    if (opts.ssh) {
+        return getPackageJsonSsh(opts, ref);
+    } else {
+        var packageUrl = 'https://' + opts.gitHubUrl + '/' + opts.package + '/raw/' + ref + '/elm-package.json';
+        return new Promise(function (fulfill, reject) {
+            request.get(packageUrl, function (error, response, body) {
+                if (error) {
+                    reject(error);
+                } else {
+                    fulfill(JSON.parse(body));
+                }
+            });
+        });
+    }
+};
+
+var getPackageJsonSsh = function(urlAndPackage, ref) {
+
+    // console.log("getPackageJsonSsh: urlAndPackage=" + JSON.stringify(urlAndPackage, null, "  ") + ", ref=" + ref);
+
+    return new Promise(function (fulfill, reject) {
+
+        var repoName = urlAndPackage.package.split('/')[1];
+
+        var cmd = 'cd /tmp && rm -rf ' + repoName +
+            ' && git clone --no-checkout --depth 1 --branch ' +
+            ref + ' git@' + urlAndPackage.gitHubUrl +
+            ':' + urlAndPackage.package + '.git &&' +
+            'cd elm-cassie && git show HEAD:elm-package.json';
+
+        // console.log("getVersions: cmd=" + cmd);
+
+        exec(cmd, function(error, stdout, stderr){
+            if (error) {
+                console.error(stdout);
+                console.error(stderr);
+                reject(error);
+            } else {
+                fulfill(JSON.parse(stdout));
+            }
+        });
+
+    });
+};
+
+
+// return the github url for package
+var packageNameToOptions = function (packageName) {
+    var parts = packageName.split(":");
+    if (parts.length == 1) {
+        return {
+            gitHubUrl: "github.com",
+            package: packageName,
+            ssh: false
+        };
+    } else if (parts.length == 2) {
+        return {
+            gitHubUrl: parts[0],
+            package: parts[1],
+            ssh: true
+        }
+    } else {
+        throw "Unsupported package name : " + packageName;
+    }
+};
+
 
 // Get all available versions (tags) for a given package
-var getVersions = function(package){
-  return new Promise(function (fulfill, reject){
-    var cmd = 'git ls-remote git://github.com/' +  package + ".git | awk -F/ '{ print $3 }'"
-    exec(cmd, function(error, stdout, stderr){
-      var versions = stdout.trim()
-                           .split("\n")
-                           .filter(function(version) {
-                              // filter out not valid tags (0.2.3^{})
-                              return semver.valid(version)
-                           })
-      fulfill(versions)
-    })
-  })
-}
+var getVersions = function (packageName) {
+
+    // console.log("getVersions: package=" + package);
+
+    var urlAndPackage = packageNameToOptions(packageName);
+
+    return new Promise(function (fulfill, reject) {
+
+        var sshStr = urlAndPackage.ssh ? '+ssh' : '';
+
+        var cmd = 'git ls-remote git' + sshStr + '://' + urlAndPackage.gitHubUrl + '/' + urlAndPackage.package + ".git | awk -F/ '{ print $3 }'";
+
+        // console.log("getVersions: cmd=" + cmd);
+
+        exec(cmd, function (error, stdout, stderr) {
+            if (error) {
+                console.error(stdout);
+                console.error(stderr);
+                reject(error);
+            } else {
+                var versions = stdout.trim()
+                    .split("\n")
+                    .filter(function (version) {
+                        // filter out not valid tags (0.2.3^{})
+                        return semver.valid(version);
+                    });
+                fulfill(versions);
+            }
+        });
+    });
+};
 
 // The installer function
-module.exports = function(){
-  // Get the config of the elm-package.json
-  var packageConfig = require(path.resolve('elm-package.json'))
+module.exports = function () {
+    // Get the config of the elm-package.json
+    var packageConfig = require(path.resolve('elm-package.json'));
 
-  // Transform dependencies into semver versions
-  var packages = transformDependencies(packageConfig.dependencies)
+    // Transform dependencies into semver versions
+    var packages = transformDependencies(packageConfig.dependencies);
 
-  // Create a resolver
-  var resolver = new SemverResolver(packages, getVersions, getDependencies)
+    // Create a resolver
+    var resolver = new SemverResolver(packages, getVersions, getDependencies);
 
-  console.log('Resolving versions...')
+    console.log('Resolving versions...');
 
-  resolver.resolve().then(function(deps){
-    // We have all the dependencies resolved
+    resolver.resolve().then(function (deps) {
+        // We have all the dependencies resolved
 
-    // Create an array of install functions
-    var installs = Object.keys(deps).map(function(package){
-      return installExternalPackage(package, deps[package])
-    })
+        // Create an array of install functions
+        var installs = Object.keys(deps).map(function (packageName) {
+            return installExternalPackage(packageName, deps[packageName]);
+        });
 
-    console.log('Starting downloads...\n')
+        console.log('Starting downloads...\n');
 
-    // Run installs in paralell
-    async.parallel(installs, function(error){
-      if(error) {
-        console.log('\nSome packages failed to install!')
-      } else {
-        // Write te exact-dependencies.json
-        fs.writeFileSync(path.resolve('elm-stuff/exact-dependencies.json'),
-                         JSON.stringify(deps, null, '  '))
-        console.log('\nPackages configured successfully!')
-      }
-    })
-  }, function(){
-    console.log('error', arguments)
-  })
-}
+        // Run installs in paralell
+        async.parallel(installs, function (error) {
+            if (error) {
+                console.log('\nSome packages failed to install!');
+            } else {
+                // Write te exact-dependencies.json
+                var depsStr = JSON.stringify(deps, null, '  ');
+                fs.writeFileSync(path.resolve('elm-stuff/exact-dependencies.json'), depsStr);
+                console.log('\nPackages configured successfully!');
+            }
+        })
+    }, function () {
+        console.log('error', arguments)
+    });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ var getPackageJsonSsh = function(packageName, ref) {
             ' && git clone --no-checkout --depth 1 --branch ' +
             ref + ' git@' + host +
             ':' + packageName + '.git &&' +
-            'cd elm-cassie && git show HEAD:elm-package.json';
+            'cd ' + repoName + ' && git show HEAD:elm-package.json';
 
         // console.log("getVersions: cmd=" + cmd);
 

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ var getVersions = function (packageName) {
 
         var cmd;
         if (isSsh(packageName)) {
-            cmd = 'git ls-remote git://' + repoHost(packageName) + '/' + packageName + ".git | awk -F/ '{ print $3 }'";
+            cmd = 'git ls-remote git@' + repoHost(packageName) + ':' + packageName + ".git | awk -F/ '{ print $3 }'";
         } else {
             cmd = 'git ls-remote git://github.com/' + packageName + ".git | awk -F/ '{ print $3 }'";
         }


### PR DESCRIPTION
This PR allows to use packages not only from github.com, but from arbitrary git+ssh remotes.
It uses a config file that indicates the host(s) of the package(s), and git commands only (no http).
This allows for easy private/corporate package repos.

See #4.