### PR TITLE
Add matchers to enable lte-defined Elm versions

### DIFF
--- a/lib/elm_install/identifier.rb
+++ b/lib/elm_install/identifier.rb
@@ -52,11 +52,12 @@ module ElmInstall
     #
     # @return [String] The version
     def elm_version(directory)
-      if json(directory)['elm-version'] =~ /<\s*0\.19/
+      case json(directory)['elm-version']
+      when /<\s*0\.19/, /<=\s*0\.18/
         '0.18'
-      elsif json(directory)['elm-version'] =~ /<\s*0\.18/
+      when /<\s*0\.18/, /<=\s*0\.17/
         '0.17'
-      elsif json(directory)['elm-version'] =~ /<\s*0\.17/
+      when /<\s*0\.17/, /<=\s*0\.16/
         '0.16'
       else
         ''


### PR DESCRIPTION
I ran into a problem when adding a dependency to `tesk9/accessible-html`, `v3.1.0`:

```
Solving dependencies...
  ▶ No solution found: Unable to satisfy the following requirements:

- `tesk9/accessible-html (< 4.0.0)` required by `user-specified dependency`
- `tesk9/accessible-html (>= 3.1.0)` required by `user-specified dependency`
```

The code to determine the Elm version of a package assumes that the version constraint is always of the shape `a.b.c <= v < x.y.z`, but `accessible-html` specifies the Elm version in different way: https://github.com/tesk9/accessible-html/blob/3.1.0/elm-package.json#L23

This is a hot fix that extends the existing hack.

### Ideas for a proper solution

The nice solution would be to resolve the Elm version constraints of the packages for compatibility. As far as I can see the Solve library does not offer that option.

How about adding the required Elm versions to the constraint set and adding an auto-detected (but configurable) Elm version to the graph?